### PR TITLE
Replace deprecated mockito methods.

### DIFF
--- a/app/src/test/java/uk/co/ribot/androidboilerplate/DataManagerTest.java
+++ b/app/src/test/java/uk/co/ribot/androidboilerplate/DataManagerTest.java
@@ -3,8 +3,9 @@ package uk.co.ribot.androidboilerplate;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +19,6 @@ import uk.co.ribot.androidboilerplate.data.model.Ribot;
 import uk.co.ribot.androidboilerplate.data.remote.RibotsService;
 import uk.co.ribot.androidboilerplate.test.common.TestDataFactory;
 
-import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -77,7 +77,7 @@ public class DataManagerTest {
         mDataManager.syncRibots().subscribe(new TestSubscriber<Ribot>());
         // Verify right calls to helper methods
         verify(mMockRibotsService).getRibots();
-        verify(mMockDatabaseHelper, never()).setRibots(anyListOf(Ribot.class));
+        verify(mMockDatabaseHelper, never()).setRibots(ArgumentMatchers.<Ribot>anyList());
     }
 
     private void stubSyncRibotsHelperCalls(List<Ribot> ribots) {

--- a/app/src/test/java/uk/co/ribot/androidboilerplate/MainPresenterTest.java
+++ b/app/src/test/java/uk/co/ribot/androidboilerplate/MainPresenterTest.java
@@ -5,8 +5,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 import java.util.List;
@@ -19,7 +20,6 @@ import uk.co.ribot.androidboilerplate.ui.main.MainMvpView;
 import uk.co.ribot.androidboilerplate.ui.main.MainPresenter;
 import uk.co.ribot.androidboilerplate.util.RxSchedulersOverrideRule;
 
-import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,7 +64,7 @@ public class MainPresenterTest {
 
         mMainPresenter.loadRibots();
         verify(mMockMainMvpView).showRibotsEmpty();
-        verify(mMockMainMvpView, never()).showRibots(anyListOf(Ribot.class));
+        verify(mMockMainMvpView, never()).showRibots(ArgumentMatchers.<Ribot>anyList());
         verify(mMockMainMvpView, never()).showError();
     }
 
@@ -76,7 +76,7 @@ public class MainPresenterTest {
         mMainPresenter.loadRibots();
         verify(mMockMainMvpView).showError();
         verify(mMockMainMvpView, never()).showRibotsEmpty();
-        verify(mMockMainMvpView, never()).showRibots(anyListOf(Ribot.class));
+        verify(mMockMainMvpView, never()).showRibots(ArgumentMatchers.<Ribot>anyList());
     }
 
 }


### PR DESCRIPTION
Changes:

- org.mockito.runners.MockitoJUnitRunner -> The import now needs to be changed to org.mockito.junit.MockitoJUnitRunner
- anyListOf(java.lang.Class<T>) -> Used in a couple of our tests, now deprecated will need to be changed to use the anyList() method. eg: anyListOf(Ribot.class) -> ArgumentMatchers.<Ribot>anyList()